### PR TITLE
Update to kotlin version 2.3.20.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -122,7 +122,7 @@ const wasmInstance = await WebAssembly.instantiate(module, {
   "wasi_snapshot_preview1": context.exports,
 });
 
-context.initialize(wasmInstance);
+context.start(wasmInstance);
 wasmInstance.exports.startUnitTests?.();
 """
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.3.0"
+kotlin = "2.3.20"
 undercouch = "5.6.0"
 
 [libraries]


### PR DESCRIPTION
Postponed until release of Kotlin and Multiplatform.

With changed initialization scheme of generated Wasm modules, running wasm/wasi from Node/Deno now requires calling `start` function, instead of `initialize`